### PR TITLE
Setup Quantization and Remvoing Distributed [not for land]

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,7 @@
+python example_chat_completion.py \
+    --ckpt_dir checkpoints/rlhf_1_llama3_7B_pt2925k_annealed_sft_s5000_notools_mp4 \
+    --tokenizer_path checkpoints/rlhf_1_llama3_7B_pt2925k_annealed_sft_s5000_notools_mp4/tokenizer.model \
+    --model_name model.pth \
+    --quantization_mode "no" \
+    --torch_compile False \
+    --max_seq_len 1024 --max_batch_size 1

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,20 @@
+mkdir checkpoints
+mkdir checkpoints/rlhf_1_llama3_7B_pt2925k_annealed_sft_s5000_notools_mp4
+manifold get llama3_partner_engineering_only/tree/rlhf_1_llama3_7B_pt2925k_annealed_sft_s5000_notools_mp4/consolidated.0.pth checkpoints/rlhf_1_llama3_7B_pt2925k_annealed_sft_s5000_notools_mp4/consolidated.0.pth
+manifold get llama3_partner_engineering_only/tree/rlhf_1_llama3_7B_pt2925k_annealed_sft_s5000_notools_mp4/consolidated.1.pth checkpoints/rlhf_1_llama3_7B_pt2925k_annealed_sft_s5000_notools_mp4/consolidated.1.pth
+manifold get llama3_partner_engineering_only/tree/rlhf_1_llama3_7B_pt2925k_annealed_sft_s5000_notools_mp4/consolidated.2.pth checkpoints/rlhf_1_llama3_7B_pt2925k_annealed_sft_s5000_notools_mp4/consolidated.2.pth
+manifold get llama3_partner_engineering_only/tree/rlhf_1_llama3_7B_pt2925k_annealed_sft_s5000_notools_mp4/consolidated.3.pth checkpoints/rlhf_1_llama3_7B_pt2925k_annealed_sft_s5000_notools_mp4/consolidated.3.pth
+manifold get llama3_partner_engineering_only/tree/v3_7b_2925k_annealed_mp1/cl_toplang_128k checkpoints/rlhf_1_llama3_7B_pt2925k_annealed_sft_s5000_notools_mp4/tokenizer.model
+echo """{
+    \"dim\": 4096,
+    \"n_layers\": 32,
+    \"n_heads\": 32,
+    \"n_kv_heads\": 8,
+    \"vocab_size\": 128256,
+    \"multiple_of\": 1024,
+    \"ffn_dim_multiplier\": 1.3,
+    \"norm_eps\": 1e-05
+}""" > checkpoints/rlhf_1_llama3_7B_pt2925k_annealed_sft_s5000_notools_mp4/params.json
+
+python unshard_model.py \
+    --ckpt_dir checkpoints/rlhf_1_llama3_7B_pt2925k_annealed_sft_s5000_notools_mp4 \

--- a/unshard_model.py
+++ b/unshard_model.py
@@ -1,0 +1,36 @@
+from typing import List, Optional
+import torch
+import fire
+from pathlib import Path
+import re
+
+def main(
+    ckpt_dir: str,
+):
+    checkpoints = sorted(Path(ckpt_dir).glob("*.pth"))
+
+    assert len(checkpoints) > 0, f"no checkpoint files found in {ckpt_dir}"
+    cps = []
+    check_name=re.compile("[^.]*[.][0-9]*[.]pth$")
+    for cp in checkpoints:
+        assert check_name.match(cp.name), f"found {cp.name} which does not match expected name format <name>.<digits>.pth"
+        cps.append(torch.load(cp, map_location="cpu", mmap=True))
+    print(f"Combining {''.join([x.name+', ' for x in checkpoints])} into combined.pth")
+    combined_cp={}
+    for key in cps[0].keys():
+        if not torch.allclose(cps[0][key], cps[1][key]):
+            values = (cps[0][key], cps[1][key], cps[2][key], cps[3][key])
+            if "wo" in key or "w2" in key:
+                # Concat on dim=1 for "wo" and "w2".
+                combined_cp[key] = torch.cat(values, dim=1)
+            else:
+                # Concat on dim=0 for everything else.
+                combined_cp[key] = torch.cat(values, dim=0)
+        else:
+            # Do not duplicate layers shared between each checkpoint.
+            combined_cp[key] = cps[0][key]
+    torch.save(combined_cp, Path(ckpt_dir) / "model.pth")
+
+
+if __name__ == "__main__":
+    fire.Fire(main)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #10

Summary: This PR allows users to more easily set things up, apply
quantization+compilation and run the model without the distributed
framework. 

Basic setup is handled by setup.sh (assuming you have access to the manifold) which downloads the model weights, tokenizer, renames them, sets up params.json and conslidates model weights and puts it all in the correct directory. Once done you should be able to simply run the test plan

You can also use unshard_model.py to conslidate other model weights.

Test Plan: 

sh run.sh

Reviewers:

Subscribers:

Tasks:

Tags: