### PR TITLE
Issue #33: Update broken URL in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,11 @@ Complete your CLA here: <https://code.facebook.com/cla>
 We use GitHub issues to track public bugs. Please ensure your description is
 clear and has sufficient instructions to be able to reproduce the issue.
 
-Meta has a [bounty program](https://bugbounty.meta.com/) for the safe
+Meta has a [bounty program](https://www.facebook.com/whitehat/) for the safe
 disclosure of security bugs. In those cases, please go through the process
 outlined on that page and do not file a public issue.
 
-## Coding Style  
+## Coding Style
 * 2 spaces for indentation rather than tabs
 * 80 character line length
 * ...


### PR DESCRIPTION
## Overview
This pull request updates the broken URL for the bug bounty program in the CONTRIBUTING.md file.

## Changes
- Updated the URL for the bug bounty program from `https://bugbounty.meta.com/` to `https://www.facebook.com/whitehat/`.

## Motivation
The current URL for the bug bounty program is not accessible and leads to a "Page Not Found" error. This change ensures that contributors can access the correct bug bounty program page when reporting security bugs.

## Testing
- Verified that the updated URL is accessible and leads to the correct bug bounty program page.

Please let me know if you have any questions or if there's anything else I can improve in this pull request.

Fixes #33 