### PR TITLE
Enable users to easily run the README example on cloud GPUs with “Open in Studio” badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ huggingface-cli download meta-llama/Meta-Llama-3-8B-Instruct --include "original
 
 ## Quick Start
 
-<a target="_blank" href="https://lightning.ai/lightning-ai/studios/chat-with-meta-s-llama-3-8b">
+<a target="_blank" href="https://lightning.ai/lightning-ai/studios/chat-with-meta-s-llama-3">
   <img src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/app-2/studio-badge.svg" alt="Open In Studio"/>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ huggingface-cli download meta-llama/Meta-Llama-3-8B-Instruct --include "original
 
 ## Quick Start
 
-<a target="_blank" href="https://lightning.ai/lightning-ai/studios/chat-with-meta-s-llama-3">
+<a target="_blank" href="https://lightning.ai/lightning-ai/studios/chat-with-llama-3-llm-by-meta-ai">
   <img src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/app-2/studio-badge.svg" alt="Open In Studio"/>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,11 @@ huggingface-cli download meta-llama/Meta-Llama-3-8B-Instruct --include "original
 
 ## Quick Start
 
-You can follow the steps below to quickly get up and running with Llama 3 models. These steps will let you run quick inference locally. For more examples, see the [Llama recipes repository](https://github.com/facebookresearch/llama-recipes).
+<a target="_blank" href="https://lightning.ai/lightning-ai/studios/chat-with-meta-s-llama-3-8b">
+  <img src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/app-2/studio-badge.svg" alt="Open In Studio"/>
+</a>
+
+You can follow the steps below to quickly get up and running with Llama 3 models or use the Lightning AI Studio linked above. These steps will let you run quick inference locally, or self-hosted in the Studio. For more examples, see the [Llama recipes repository](https://github.com/facebookresearch/llama-recipes).
 
 1. In a conda env with PyTorch / CUDA available clone and download this repository.
 


### PR DESCRIPTION
Update the Quick Start section of the README to add an `Open in Studio` badge to allow users to run the example on a free L4 GPU on Lightning AI.

<img src=https://github.com/meta-llama/llama3/assets/26209687/b7b70507-0e97-40bb-a3a8-a5d3a08d6560  height="150">

