### PR TITLE
Minor grammatical improvement and typo fix - README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can follow the steps below to quickly get up and running with Llama 3 models
 4. Once registered, you will get an email with a URL to download the models. You will need this URL when you run the download.sh script.
 
 5. Once you get the email, navigate to your downloaded llama repository and run the download.sh script.
-    - Make sure to grant execution permissions to the download.sh script
+    - Make sure to grant execution permissions to the download.sh script.
     - During this process, you will be prompted to enter the URL from the email.
     - Do not use the “Copy Link” option but rather make sure to manually copy the link from the email.
 
@@ -85,7 +85,7 @@ torchrun --nproc_per_node 1 example_chat_completion.py \
 - Replace  `Meta-Llama-3-8B-Instruct/` with the path to your checkpoint directory and `Meta-Llama-3-8B-Instruct/tokenizer.model` with the path to your tokenizer model.
 - The `–nproc_per_node` should be set to the [MP](#inference) value for the model you are using.
 - Adjust the `max_seq_len` and `max_batch_size` parameters as needed.
-- This example runs the [example_chat_completion.py](example_chat_completion.py) found in this repository but you can change that to a different .py file.
+- This example runs the [example_chat_completion.py](example_chat_completion.py) found in this repository, but you can change that to a different .py file.
 
 ## Inference
 


### PR DESCRIPTION
- Added a comma for better readability in the sentence "This example runs the example_chat_completion.py found in this repository, but you can change that to a different .py file."
- Fixed a typo in the sentence "Make sure to grant execution permissions to the download.sh script."