### PR TITLE
KJSL: If CPU_ARCH is not set, e.g. on Apple Silicon ARM, then use uname

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -51,6 +51,7 @@ do
     wget --continue ${PRESIGNED_URL/'*'/"${MODEL_PATH}/tokenizer.model"} -O ${TARGET_FOLDER}"/${MODEL_FOLDER_PATH}/tokenizer.model"
     wget --continue ${PRESIGNED_URL/'*'/"${MODEL_PATH}/checklist.chk"} -O ${TARGET_FOLDER}"/${MODEL_FOLDER_PATH}/checklist.chk"
     echo "Checking checksums"
+    CPU_ARCH=${CPU_ARCH:-$(uname -m)}
     if [ "$CPU_ARCH" = "arm64" ]; then
       (cd ${TARGET_FOLDER}"/${MODEL_FOLDER_PATH}" && md5 checklist.chk)
     else


### PR DESCRIPTION
Download fix up for macOS (Apple Silicon ARM)