### PR TITLE
[minor] Improved `repeat_kv` eager perf

### DIFF
--- a/llama/model.py
+++ b/llama/model.py
@@ -81,7 +81,7 @@ def repeat_kv(x: torch.Tensor, n_rep: int) -> torch.Tensor:
     if n_rep == 1:
         return x
     return (
-        x[:, :, :, None, :]
+        torch.unsqueeze(x, dim=3)
         .expand(bs, slen, n_kv_heads, n_rep, head_dim)
         .reshape(bs, slen, n_kv_heads * n_rep, head_dim)
     )


### PR DESCRIPTION
This PR:
- In forward, this saves 4 `aten::slice`.
- In backward, this saves 4 `aten::fill` and 4 `aten::copy_` kernels with shape `(bs, seq_len, n_kv_heads, head_dim)`.

See https://github.com/pytorch/torchtitan/pull/418 for details and traces.

**Since this repo is hosting inference (forward-only) code, this change is not significant at all. However, since this repo also hosts the reference model implementation that others base on, even for training, this change could be helpful for others.**
