### PR TITLE
Add text vectorization with different pooling types

### DIFF
--- a/llama/generation.py
+++ b/llama/generation.py
@@ -167,7 +167,7 @@ class Llama:
         eos_reached = torch.tensor([False] * bsz, device="cuda")
         input_text_mask = tokens != pad_id
         if min_prompt_len == total_len:
-            logits, _ = self.model.forward(tokens, prev_pos)
+            logits = self.model.forward(tokens, prev_pos)
             token_logprobs = -F.cross_entropy(
                 input=logits.transpose(1, 2),
                 target=tokens,
@@ -178,7 +178,7 @@ class Llama:
         stop_tokens = torch.tensor(list(self.tokenizer.stop_tokens))
 
         for cur_pos in range(min_prompt_len, total_len):
-            logits, _ = self.model.forward(tokens[:, prev_pos:cur_pos], prev_pos)
+            logits  = self.model.forward(tokens[:, prev_pos:cur_pos], prev_pos)
             if temperature > 0:
                 probs = torch.softmax(logits[:, -1] / temperature, dim=-1)
                 next_token = sample_top_p(probs, top_p)


### PR DESCRIPTION
I have implemented a new feature in the generate_embedding function that supports text vectorization with different pooling types (mean, max, min). This enhancement allows the function to return pooled embeddings based on the specified pooling type, enabling more flexible text vectorization.